### PR TITLE
Add zsh support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,58 +1,44 @@
+#!/bin/bash
+
 ## Author: Adeeb Abbas
 # This script sets up the ros_dev function in the bashrc file.
 
 # Get the absolute path to the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Adds the following function to the bashrc file:
+# Define the function
+ros_dev() {
+  # Check if the correct number of arguments were provided
+  if (( $# % 2 != 0 )); then
+    echo "Usage: ros_dev <container_name1> <project_path1> [<container_name2> <project_path2> ...]"
+    return 1
+  fi
+
+  while (( $# >= 2 )); do
+    # Set environment variables
+    export ROS_DEV_CONTAINER_NAME=$1
+    export ROS_PROJECT_PATH=$2
+    shift 2
+
+    # Run docker-compose from the correct directory
+    cd "$SCRIPT_DIR" && docker-compose up -d --build
+  done
+}
 
 if [[ $SHELL == "/bin/bash" ]]; then
-    # Check if the function already exists in the bashrc file
-    if ! grep -q "ros_dev()" "$HOME/.bashrc"; then
-        echo 'ros_dev() {
-            # Check if the correct number of arguments were provided
-            if (( $# % 2 != 0 )); then
-                echo "Usage: ros_dev <container_name1> <project_path1> [<container_name2> <project_path2> ...]"
-                return 1
-            fi
-            while (( $# >= 2 )); do
-                # Set environment variables
-                export ROS_DEV_CONTAINER_NAME=$1
-                export ROS_PROJECT_PATH=$2
-                shift 2
-                # Run docker-compose from the correct directory
-                cd "$SCRIPT_DIR" && docker-compose up -d --build
-            done
-        }' >> "$HOME/.bashrc"
-        echo "ros_dev function added to bashrc file"
-    else
-        echo "ros_dev function already exists in bashrc file"
-    fi
-else if [[ $SHELL == "/bin/zsh" ]]; then
-    # Check if the function already exists in the zshrc file
-    if ! grep -q "ros_dev()" "$HOME/.zshrc"; then
-        echo 'ros_dev() {
-            # Check if the correct number of arguments were provided
-            if (( $# % 2 != 0 )); then
-                echo "Usage: ros_dev <container_name1> <project_path1> [<container_name2> <project_path2> ...]"
-                return 1
-            fi
-            while (( $# >= 2 )); do
-                # Set environment variables
-                export ROS_DEV_CONTAINER_NAME=$1
-                export ROS_PROJECT_PATH=$2
-                shift 2
-                # Run docker-compose from the correct directory
-                cd "$SCRIPT_DIR" && docker-compose up -d --build
-            done
-        }' >> "$HOME/.zshrc"
-        echo "ros_dev function added to zshrc file"
-    else
-        echo "ros_dev function already exists in zshrc file"
-    fi
- else
-    echo "Unsupported shell"
-    exit 1
-  fi
+  shell_config_file="$HOME/.bashrc"
+elif [[ $SHELL == "/bin/zsh" ]]; then
+  shell_config_file="$HOME/.zshrc"
+else
+  echo "Unsupported shell"
+  exit 1
 fi
+
+if ! grep -q "ros_dev ()" "$shell_config_file"; then
+  declare -f ros_dev >> "$shell_config_file"
+  echo "ros_dev function added to $shell_config_file"
+else
+  echo "ros_dev function already exists in $shell_config_file"
+fi
+
 echo "Done"

--- a/setup.sh
+++ b/setup.sh
@@ -6,25 +6,53 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Adds the following function to the bashrc file:
 
-echo "Adding ros_dev function to bashrc file"
-
-echo 'ros_dev() {
-  # Check if the correct number of arguments were provided
-  if (( $# % 2 != 0 )); then
-    echo "Usage: ros_dev <container_name1> <project_path1> [<container_name2> <project_path2> ...]"
-    return 1
+if [[ $SHELL == "/bin/bash" ]]; then
+    # Check if the function already exists in the bashrc file
+    if ! grep -q "ros_dev()" "$HOME/.bashrc"; then
+        echo 'ros_dev() {
+            # Check if the correct number of arguments were provided
+            if (( $# % 2 != 0 )); then
+                echo "Usage: ros_dev <container_name1> <project_path1> [<container_name2> <project_path2> ...]"
+                return 1
+            fi
+            while (( $# >= 2 )); do
+                # Set environment variables
+                export ROS_DEV_CONTAINER_NAME=$1
+                export ROS_PROJECT_PATH=$2
+                shift 2
+                # Run docker-compose from the correct directory
+                cd "$SCRIPT_DIR" && docker-compose up -d --build
+            done
+        }' >> "$HOME/.bashrc"
+        echo "ros_dev function added to bashrc file"
+    else
+        echo "ros_dev function already exists in bashrc file"
+    fi
+else if [[ $SHELL == "/bin/zsh" ]]; then
+    # Check if the function already exists in the zshrc file
+    if ! grep -q "ros_dev()" "$HOME/.zshrc"; then
+        echo 'ros_dev() {
+            # Check if the correct number of arguments were provided
+            if (( $# % 2 != 0 )); then
+                echo "Usage: ros_dev <container_name1> <project_path1> [<container_name2> <project_path2> ...]"
+                return 1
+            fi
+            while (( $# >= 2 )); do
+                # Set environment variables
+                export ROS_DEV_CONTAINER_NAME=$1
+                export ROS_PROJECT_PATH=$2
+                shift 2
+                # Run docker-compose from the correct directory
+                cd "$SCRIPT_DIR" && docker-compose up -d --build
+            done
+        }' >> "$HOME/.zshrc"
+        echo "ros_dev function added to zshrc file"
+    else
+        echo "ros_dev function already exists in zshrc file"
+    fi
+ else
+    echo "Unsupported shell"
+    exit 1
   fi
-
-  while (( $# >= 2 )); do
-    # Set environment variables
-    export ROS_DEV_CONTAINER_NAME=$1
-    export ROS_PROJECT_PATH=$2
-    shift 2
-
-    # Run docker-compose from the correct directory
-    cd "$SCRIPT_DIR" && docker-compose up -d --build
-  done
-}
-' >> "$HOME/.bashrc"
-
+fi
 echo "Done"


### PR DESCRIPTION
Hi 

Thanks for the repo. It was helpful to be able to run ROS GUI from docker.

 I want to add a small change to your shell script with `zsh` support. 


Thanks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adeeb10abbas/ros2-docker-dev/6)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `ros_dev()` function to the user's shell configuration (`~/.bashrc` or `~/.zshrc`) for setting environment variables and running `docker-compose` for ROS development.

- **Improvements**
  - Enhanced the `setup.sh` script to automatically detect the user's shell and add the `ros_dev()` function accordingly.
  - Improved script readability and maintainability with refactoring and added comments.
  - Added error handling and user messages for unsupported shells and incorrect function usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->