### PR TITLE
Noetic docker compose cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: ${ROS_DEV_CONTAINER_NAME} ## For now, the names are the same. Can change if ever a need arises.
     build: ./
     volumes: 
-      - ${ROS_PROJECT_PATH}:/ros2_ws/src/
+      - ${ROS_PROJECT_PATH}:/ros1_ws/src/
     environment:
       - DISPLAY=novnc:0.0
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@
 #
 # Author: Adeeb Abbas
 
-version: '3.8'
 services:
   ros_dev_env:
     container_name: ${ROS_DEV_CONTAINER_NAME}


### PR DESCRIPTION
The version of the Docker Compose file is obsolete and prints a warning.
I also changed the workspace name from ros2 to ros1

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adeeb10abbas/ros2-docker-dev/8)
<!-- Reviewable:end -->
