### PR TITLE
Remove obsolete version in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@
 #
 # Author: Adeeb Abbas
 
-version: '3.8'
 services:
   ros_dev_env:
     container_name: ${ROS_DEV_CONTAINER_NAME}


### PR DESCRIPTION
The version field in the Docker Compose file is obsolete and prints a warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adeeb10abbas/ros2-docker-dev/9)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configurations in the `docker-compose.yml` for existing services without introducing new functionality. 
	- Maintained environment variable settings and volume mappings for consistent service operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->